### PR TITLE
Refactor/mb62 refactor strategy reward history

### DIFF
--- a/src/logic/StrategyRewardHistory.js
+++ b/src/logic/StrategyRewardHistory.js
@@ -7,26 +7,48 @@ export default class StrategyRewardHistory {
     epsilonGreedyRewards = [];
 
     /**
-     * Append a reward to one of the managed arrays.
-     * The arrRef must be exactly one of the instance arrays.
+     * Synchronizes one of the cumulative reward arrays with the observedRewards of a given object.
+     * The arrRef must be exactly one of the instance arrays (manualRewards, greedyRewards, epsilonGreedyRewards).
      *
-     * @param {Array} arrRef - reference to the target array (must be one of the three internal arrays)
-     * @param {number} reward - the reward value to append
+     * @param {Array} arrRef - reference to the target cumulative array (one of the three internal arrays)
+     * @param {Object} obj - object containing an observedRewards array
      */
-    addReward(arrRef, reward) {
+    addReward(arrRef, obj) {
+        // --- Validate target array ---
         if (arrRef !== this.manualRewards && arrRef !== this.greedyRewards && arrRef !== this.epsilonGreedyRewards) {
-            throw new Error('addReward: provided array is not managed by StrategyRewardHistory. Use one of the instance arrays.');
-        }
-        if (typeof reward !== 'number') {
-            throw new Error('Reward must be a number.');
+            throw new Error('addReward: provided array is not managed by StrategyRewardHistory.');
         }
 
-        const previousTotal = arrRef.length > 0 ? arrRef[arrRef.length - 1] : 0;
-        const newTotal = previousTotal + reward;
+        // --- Validate source object ---
+        if (!obj || !Array.isArray(obj.observedRewards)) {
+            throw new Error('addReward: provided object must contain an observedRewards array.');
+        }
 
-        // Append the cumulative value
-        arrRef.push(newTotal);
-        console.log(`Reward ${reward} added to array ${arrRef}.`);
+        const src = obj.observedRewards;
+        const dest = arrRef;
+
+        // If source and destination already have the same length → nothing to do
+        if (dest.length === src.length) return;
+
+        // If source has fewer elements than destination → inconsistent
+        if (src.length < dest.length) {
+            throw new Error('addReward: observedRewards array is shorter than cumulative array — cannot sync.');
+        }
+
+        // Continue cumulatively from the last known sum
+        let runningTotal = dest.length > 0 ? dest[dest.length - 1] : 0;
+
+        // Process new rewards
+        for (let i = dest.length; i < src.length; i++) {
+            const reward = src[i];
+
+            if (typeof reward !== 'number' || !Number.isFinite(reward)) {
+                throw new Error(`addReward: invalid reward value at index ${i}. Must be a finite number.`);
+            }
+
+            runningTotal += reward;
+            dest.push(runningTotal);
+        }
     }
 
     /**

--- a/src/logic/StrategyRewardHistory.test.js
+++ b/src/logic/StrategyRewardHistory.test.js
@@ -8,43 +8,54 @@ describe('StrategyRewardHistory', () => {
         history = new StrategyRewardHistory();
     });
 
-    it('adds integer rewards correctly', () => {
-        history.addReward(history.manualRewards, 1);
-        history.addReward(history.manualRewards, 0);
-        expect(history.manualRewards).toEqual([1, 1]);
+    it('adds integer rewards correctly from object', () => {
+        const obj = { observedRewards: [1, 0, -3] };
+        history.addReward(history.manualRewards, obj);
+        expect(history.manualRewards).toEqual([1, 1, -2]);
     });
 
-    it('allows floating point rewards (current implementation)', () => {
-        history.addReward(history.greedyRewards, 0.5);
-        history.addReward(history.greedyRewards, 3.14);
+    it('adds floating point rewards correctly from object', () => {
+        const obj = { observedRewards: [0.5, 3.14] };
+        history.addReward(history.greedyRewards, obj);
         expect(history.greedyRewards).toEqual([0.5, 3.64]);
     });
 
-    it('allows negative numbers', () => {
-        history.addReward(history.epsilonGreedyRewards, -2);
+    it('adds negative numbers correctly from object', () => {
+        const obj = { observedRewards: [-2] };
+        history.addReward(history.epsilonGreedyRewards, obj);
         expect(history.epsilonGreedyRewards).toEqual([-2]);
     });
 
-    it('throws error if non-numeric value is passed', () => {
-        // Die Funktion, die einen Fehler werfen soll, muss in eine anonyme Funktion gekapselt werden.
-        expect(() => history.addReward(history.manualRewards, 'reward')).toThrow();
+    it('throws error if object does not contain an observedRewards array', () => {
         expect(() => history.addReward(history.manualRewards, null)).toThrow();
-        expect(() => history.addReward(history.manualRewards, { value: 1 })).toThrow();
-        expect(() => history.addReward(history.manualRewards, undefined)).toThrow();
-
-        // Zusätzlich wird sichergestellt, dass das Array nach den fehlgeschlagenen Versuchen leer bleibt.
-        expect(history.manualRewards).toEqual([]);
+        expect(() => history.addReward(history.manualRewards, {})).toThrow();
+        expect(() => history.addReward(history.manualRewards, { observedRewards: 'notArray' })).toThrow();
     });
 
     it('throws error if non-managed array is passed', () => {
         const fakeArray = [];
-        expect(() => history.addReward(fakeArray, 42)).toThrow();
+        const obj = { observedRewards: [1] };
+        expect(() => history.addReward(fakeArray, obj)).toThrow();
+    });
+
+    it('throws error if observedRewards is shorter than cumulative array', () => {
+        history.manualRewards.push(1, 2);
+        const obj = { observedRewards: [1] };
+        expect(() => history.addReward(history.manualRewards, obj)).toThrow();
+    });
+
+    it('does nothing if observedRewards length equals cumulative array length', () => {
+        const obj = { observedRewards: [1, 2] };
+        history.manualRewards.push(1, 3); // already cumulative sum
+        history.addReward(history.manualRewards, obj);
+        // Array should remain unchanged
+        expect(history.manualRewards).toEqual([1, 3]);
     });
 
     it('resets all arrays', () => {
-        history.addReward(history.manualRewards, 1);
-        history.addReward(history.greedyRewards, 2.5);
-        history.addReward(history.epsilonGreedyRewards, -5);
+        history.addReward(history.manualRewards, { observedRewards: [1] });
+        history.addReward(history.greedyRewards, { observedRewards: [2.5] });
+        history.addReward(history.epsilonGreedyRewards, { observedRewards: [-5] });
 
         history.reset();
 


### PR DESCRIPTION
Die Methode addReward wurde so angepasst, dass die Arrays, die @DariaL-git mit den Alrogithmen-Objekten bereitstellt, abgegriffen und kumuliert werden. Somit müsste die Methode so abgerufen werden, dass passendes Objekt und passendes Array als Parameter weitergegeben werden müssen. Bitte einmal prüfen, ob diese Art des Aufrufes für die zukünfitgen Implementierungen in Ordnung ist.